### PR TITLE
Add remote_src: yes to unarchive and copy commands

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,11 +20,13 @@
 
 - name: Unpack Helm dist archive
   unarchive:
+    remote_src: yes
     src: '{{ helm_tempdir.path }}/helm-v{{ helm_version }}-linux-amd64.tar.gz'
     dest: '{{ helm_tempdir.path }}/'
 
 - name: Install Helm binary
   copy:
+    remote_src: yes
     src: '{{ helm_tempdir.path }}/linux-amd64/helm'
     dest: /usr/local/bin/helm
     mode: 0755


### PR DESCRIPTION
In tasks/install.yml, the `unarchive` and `copy` steps were failing because they both expect the file to be on the controller machine, rather than to the remote machine (where the package gets downloaded to). This is fixed by adding `remote_src: yes` to both of them.